### PR TITLE
fix: do not escape hash symbol in regex

### DIFF
--- a/src/unison_gitignore/parser.py
+++ b/src/unison_gitignore/parser.py
@@ -104,5 +104,7 @@ class UnisonPathIgnore:
 
     def __str__(self):
         s = "-ignore" if self.include else "-ignorenot"
-        escaped_regex = self.regex.replace("\\~", "~").replace("\\-", "-")
+        escaped_regex = (
+            self.regex.replace("\\~", "~").replace("\\-", "-").replace("\\#", "#")
+        )
         return f"{s}=Regex {escaped_regex}"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,7 +22,7 @@ def test_root_path_removes_slash():
     assert parsed[0].anchor_path == ""
 
 
-def test_escaped_hash():
+def test_hash_should_not_be_escaped():
     parsed = GitIgnoreToUnisonIgnore(".#*").parse_gitignore(StringIO(".#file"))
     assert len(parsed) == 1
     assert str(parsed[0]) == r"-ignore=Regex ^.#*/(.+/)?\.#file(/.*)?$"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,6 +22,12 @@ def test_root_path_removes_slash():
     assert parsed[0].anchor_path == ""
 
 
+def test_escaped_hash():
+    parsed = GitIgnoreToUnisonIgnore(".#*").parse_gitignore(StringIO(".#file"))
+    assert len(parsed) == 1
+    assert str(parsed[0]) == r"-ignore=Regex ^.#*/(.+/)?\.#file(/.*)?$"
+
+
 def test_accepts_array_of_strings():
     parsed = GitIgnoreToUnisonIgnore("/").parse_gitignore(["test1.py", "test2.py"])
     assert len(parsed) == 2


### PR DESCRIPTION
It's escaped because of https://python-path-specification.readthedocs.io/en/latest/_modules/pathspec/patterns/gitwildmatch.html#GitWildMatchPattern.pattern_to_regex

The `#` symbol is not a special regex char.